### PR TITLE
Fix preemptive upload of active video files

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import webbrowser
 from mimetypes import guess_type
 from os.path import basename, isfile, splitext, getsize, exists
+from os import rename
 from time import sleep
 
 from pyperclip import copy
@@ -48,6 +49,15 @@ def validate_file(path):
         print(f"Error: {basename(path)} exceeds the permitted file size limit "
               f"({getsize(path) / (1 << 20):.2f}MB > 40MB).")
         return False
+
+    
+    # Validation check for actively written video format files
+    if exists(path):
+        try:
+            rename(path, path) # Attemps to "rename" the file when being validated, which errors if the file is in use
+                               # This ensures that a video will only upload when ready 
+        except OSError:
+            return False
 
     return True
 


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull request type

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [x] Feature

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When using using the auto-uploader to monitor a folder that you may write videos to, it tries to upload a partially written video file, which Zipline sees as broken/invalid.

Issue Number: N/A

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adds an additional verification check by attempting to rename the file, if it is able to rename the file, it treats it as valid. If it cannot rename the file, that means that it is being used by some application still and will wait until it is finished to upload.

## Other information

Tested functionality with ShareX screen recorder writing to monitored folder.
